### PR TITLE
Modify commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Focusing on visualising complexity of code, using [Cognitive Complexity](https:/
 ### Single File Analysis
 
 ```sh
-$ go run main.go path/to/file.vbs
+$ go run main.go single path/to/file.vbs
 ```
 
 ### Multi File Analysis

--- a/cmd/directory.go
+++ b/cmd/directory.go
@@ -12,7 +12,7 @@ import (
 )
 
 var directoryCommand = &cobra.Command{
-	Use:   "directory",
+	Use:   "directory [path to directory]",
 	Short: "calculate files inside the directory",
 	Args:  cobra.RangeArgs(1, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "refactoring-conductor",
+	Short: "CLI tool written in Go for performing static analysis, using cognitive complexity",
+}
+
+// Execute is to execute main command line tool.
+func Execute() {
+	rootCmd.SetHelpCommand(&cobra.Command{
+		Use:    "no-help",
+		Hidden: true,
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/single_file.go
+++ b/cmd/single_file.go
@@ -4,16 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/st-tech/refactoring-conductor/domain"
 	"github.com/st-tech/refactoring-conductor/internal"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "cog [file name]",
-	Short: "Command line cognitive complexity",
+var singleFileCmd = &cobra.Command{
+	Use:   "single [file name]",
+	Short: "Calculate cognitive complexity of single file.",
 	Args:  cobra.RangeArgs(1, 10),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -43,10 +42,6 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// Execute is to execute main command line tool.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+func init() {
+	rootCmd.AddCommand(singleFileCmd)
 }


### PR DESCRIPTION
# Abstract
Modified few files, to make comment and command consistent. 

# Description
Currently. help is showing that there's  `cog` command, but actually doesn't. (And to guess the meaning of `cog` was difficult to understand for me)
- Changed to show usage when executing root command
- To analyze single file, added `single` command
- Disabled help command

### Before 
```sh
Usage:
  cog [file name] [flags]
  cog [command]

Available Commands:
  directory   calculate files inside the directory
  help        Help about any command

Flags:
  -h, --help   help for cog

Use "cog [command] --help" for more information about a command.

accepts between 1 and 10 arg(s), received 0
```

### After
```sh
CLI tool written in Go for performing static analysis, using cognitive complexity

Usage:
  refactoring-conductor [command]

Available Commands:
  directory   calculate files inside the directory
  single      Calculate cognitive complexity of single file.

Flags:
  -h, --help   help for refactoring-conductor

Use "refactoring-conductor [command] --help" for more information about a command.
```